### PR TITLE
BM-1602 and BM-1605 : add more logging to Pesapal IPN

### DIFF
--- a/src/Ericmuigai/Pesapal/Oauth/Ipnlisten.php
+++ b/src/Ericmuigai/Pesapal/Oauth/Ipnlisten.php
@@ -3,6 +3,7 @@
 use Oneafricamedia\Core\Services\PaymentService;
 use OAuthException;
 use Input;
+use Log;
 
 /**
  * Class Ipnlisten
@@ -66,6 +67,7 @@ class Ipnlisten
 
                 //transaction status
                 $elements = preg_split("/=/", substr($response, $header_size));
+                Log::info("Pesapal Status update fetched for Order : {$pesapal_merchant_reference} ", ['elements'=>$elements]);
                 $this->paymentService->respondToPaymentNotification(
                     $elements,
                     $pesapal_merchant_reference,


### PR DESCRIPTION
After investigating BM-1602 and BM-1605 I realised it would be very useful to actually have sight of what data Pesapal is giving to us. Nowhere in our logs do we see what the actual transaction status update is from Pesapal which makes debugging quite hard.

Please review the log change that I've made, test it if you can and make the changes to your repo or merge in this PR. Thanks!
